### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/random-iceberg/web-frontend/security/code-scanning/1](https://github.com/random-iceberg/web-frontend/security/code-scanning/1)

To fix the issue, we need to add an explicit `permissions` block to the `test` job in the workflow file. Since the `test` job only requires read access to the repository contents, we will set `contents: read` as the permission. This change ensures that the job adheres to the principle of least privilege and does not inherit potentially excessive permissions from the repository.

The changes will be made in the `.github/workflows/ci.yml` file, specifically within the `test` job definition. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
